### PR TITLE
Fix floating point exceptions on zero length vector

### DIFF
--- a/kazmath/vec2.c
+++ b/kazmath/vec2.c
@@ -49,6 +49,9 @@ kmScalar kmVec2LengthSq(const kmVec2* pIn)
 
 kmVec2* kmVec2Normalize(kmVec2* pOut, const kmVec2* pIn)
 {
+        if (!pIn->x && !pIn->y)
+                return kmVec2Assign(pOut, pIn);
+
 	kmScalar l = 1.0f / kmVec2Length(pIn);
 
 	kmVec2 v;

--- a/kazmath/vec3.c
+++ b/kazmath/vec3.c
@@ -70,7 +70,10 @@ kmScalar kmVec3LengthSq(const kmVec3* pIn)
   */
 kmVec3* kmVec3Normalize(kmVec3* pOut, const kmVec3* pIn)
 {
-	kmScalar l = 1.0f / kmVec3Length(pIn);
+        if (!pIn->x && !pIn->y && !pIn->z)
+                return kmVec3Assign(pOut, pIn);
+
+        kmScalar l = 1.0f / kmVec3Length(pIn);
 
 	kmVec3 v;
 	v.x = pIn->x * l;


### PR DESCRIPTION
- If the vector lengths are zero, the division
  will cause floating point exception.

To caught such errors in future, I suggest trapping SIGFPE in tests
and maybe using feenableexcept.
