### PR TITLE
Fix 'const type qualifier' warnings on GCC -Wextra

### DIFF
--- a/kazmath/aabb.c
+++ b/kazmath/aabb.c
@@ -52,7 +52,7 @@ kmAABB* kmAABBInitialize(kmAABB* pBox, const kmVec3* centre, const kmScalar widt
  * Returns KM_TRUE if point is in the specified AABB, returns
  * KM_FALSE otherwise.
  */
-const int kmAABBContainsPoint(const kmAABB* pBox, const kmVec3* pPoint)
+int kmAABBContainsPoint(const kmAABB* pBox, const kmVec3* pPoint)
 {
     if(pPoint->x >= pBox->min.x && pPoint->x <= pBox->max.x &&
        pPoint->y >= pBox->min.y && pPoint->y <= pBox->max.y &&
@@ -66,7 +66,7 @@ const int kmAABBContainsPoint(const kmAABB* pBox, const kmVec3* pPoint)
 /**
  * Assigns pIn to pOut, returns pOut.
  */
-kmAABB* const kmAABBAssign(kmAABB* pOut, const kmAABB* pIn)
+kmAABB* kmAABBAssign(kmAABB* pOut, const kmAABB* pIn)
 {
     kmVec3Assign(&pOut->min, &pIn->min);
     kmVec3Assign(&pOut->max, &pIn->max);
@@ -76,7 +76,7 @@ kmAABB* const kmAABBAssign(kmAABB* pOut, const kmAABB* pIn)
 /**
  * Scales pIn by s, stores the resulting AABB in pOut. Returns pOut
  */
-kmAABB* const kmAABBScale(kmAABB* pOut, const kmAABB* pIn, kmScalar s)
+kmAABB* kmAABBScale(kmAABB* pOut, const kmAABB* pIn, kmScalar s)
 {
 	assert(0 && "Not implemented");
 }

--- a/kazmath/aabb.h
+++ b/kazmath/aabb.h
@@ -44,9 +44,9 @@ typedef struct kmAABB {
 
 
 kmAABB* kmAABBInitialize(kmAABB* pBox, const kmVec3* centre, const kmScalar width, const kmScalar height, const kmScalar depth);
-const int kmAABBContainsPoint(const kmAABB* pBox, const kmVec3* pPoint);
-kmAABB* const kmAABBAssign(kmAABB* pOut, const kmAABB* pIn);
-kmAABB* const kmAABBScale(kmAABB* pOut, const kmAABB* pIn, kmScalar s);
+int kmAABBContainsPoint(const kmAABB* pBox, const kmVec3* pPoint);
+kmAABB* kmAABBAssign(kmAABB* pOut, const kmAABB* pIn);
+kmAABB* kmAABBScale(kmAABB* pOut, const kmAABB* pIn, kmScalar s);
 kmBool kmAABBIntersectsTriangle(kmAABB* box, const kmVec3* p1, const kmVec3* p2, const kmVec3* p3);
 kmEnum kmAABBContainsAABB(const kmAABB* container, const kmAABB* to_check);
 kmScalar kmAABBDiameterX(const kmAABB* aabb);

--- a/kazmath/mat3.c
+++ b/kazmath/mat3.c
@@ -33,21 +33,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "mat4.h"
 #include "quaternion.h"
 
-kmMat3* const kmMat3Fill(kmMat3* pOut, const kmScalar* pMat)
+kmMat3* kmMat3Fill(kmMat3* pOut, const kmScalar* pMat)
 {
     memcpy(pOut->mat, pMat, sizeof(kmScalar) * 9);
     return pOut;
 }
 
 /** Sets pOut to an identity matrix returns pOut*/
-kmMat3* const kmMat3Identity(kmMat3* pOut)
+kmMat3* kmMat3Identity(kmMat3* pOut)
 {
 	memset(pOut->mat, 0, sizeof(kmScalar) * 9);
 	pOut->mat[0] = pOut->mat[4] = pOut->mat[8] = 1.0f;
 	return pOut;
 }
 
-const kmScalar kmMat3Determinant(const kmMat3* pIn)
+kmScalar kmMat3Determinant(const kmMat3* pIn)
 {
     kmScalar output;
     /*
@@ -66,7 +66,7 @@ const kmScalar kmMat3Determinant(const kmMat3* pIn)
 }
 
 
-kmMat3* const kmMat3Adjugate(kmMat3* pOut, const kmMat3* pIn)
+kmMat3* kmMat3Adjugate(kmMat3* pOut, const kmMat3* pIn)
 {
     pOut->mat[0] = pIn->mat[4] * pIn->mat[8] - pIn->mat[5] * pIn->mat[7];
     pOut->mat[1] = pIn->mat[2] * pIn->mat[7] - pIn->mat[1] * pIn->mat[8];
@@ -81,7 +81,7 @@ kmMat3* const kmMat3Adjugate(kmMat3* pOut, const kmMat3* pIn)
     return pOut;
 }
 
-kmMat3* const kmMat3Inverse(kmMat3* pOut, const kmMat3* pM)
+kmMat3* kmMat3Inverse(kmMat3* pOut, const kmMat3* pM)
 {
     kmScalar determinate = kmMat3Determinant(pM);
     kmScalar detInv;
@@ -101,9 +101,9 @@ kmMat3* const kmMat3Inverse(kmMat3* pOut, const kmMat3* pM)
 }
 
 /** Returns true if pIn is an identity matrix */
-const int kmMat3IsIdentity(const kmMat3* pIn)
+int kmMat3IsIdentity(const kmMat3* pIn)
 {
-	static const kmScalar identity [] = { 	1.0f, 0.0f, 0.0f,
+	static kmScalar identity [] = { 	1.0f, 0.0f, 0.0f,
 										0.0f, 1.0f, 0.0f,
 										0.0f, 0.0f, 1.0f};
 
@@ -111,7 +111,7 @@ const int kmMat3IsIdentity(const kmMat3* pIn)
 }
 
 /** Sets pOut to the transpose of pIn, returns pOut */
-kmMat3* const kmMat3Transpose(kmMat3* pOut, const kmMat3* pIn)
+kmMat3* kmMat3Transpose(kmMat3* pOut, const kmMat3* pIn)
 {
     kmScalar temp[9];
     
@@ -133,7 +133,7 @@ kmMat3* const kmMat3Transpose(kmMat3* pOut, const kmMat3* pIn)
 }
 
 /* Multiplies pM1 with pM2, stores the result in pOut, returns pOut */
-kmMat3* const kmMat3Multiply(kmMat3* pOut, const kmMat3* pM1, const kmMat3* pM2)
+kmMat3* kmMat3Multiply(kmMat3* pOut, const kmMat3* pM1, const kmMat3* pM2)
 {
 	kmScalar mat[9];
 
@@ -156,7 +156,7 @@ kmMat3* const kmMat3Multiply(kmMat3* pOut, const kmMat3* pM1, const kmMat3* pM2)
 	return pOut;
 }
 
-kmMat3* const kmMat3ScalarMultiply(kmMat3* pOut, const kmMat3* pM, const kmScalar pFactor)
+kmMat3* kmMat3ScalarMultiply(kmMat3* pOut, const kmMat3* pM, const kmScalar pFactor)
 {
     kmScalar mat[9];
     int i;
@@ -172,7 +172,7 @@ kmMat3* const kmMat3ScalarMultiply(kmMat3* pOut, const kmMat3* pM, const kmScala
 }
 
 /** Assigns the value of pIn to pOut */
-kmMat3* const kmMat3Assign(kmMat3* pOut, const kmMat3* pIn)
+kmMat3* kmMat3Assign(kmMat3* pOut, const kmMat3* pIn)
 {
 	assert(pOut != pIn); //You have tried to self-assign!!
 
@@ -181,7 +181,7 @@ kmMat3* const kmMat3Assign(kmMat3* pOut, const kmMat3* pIn)
 	return pOut;
 }
 
-kmMat3* const kmMat3AssignMat4(kmMat3* pOut, const kmMat4* pIn) {
+kmMat3* kmMat3AssignMat4(kmMat3* pOut, const kmMat4* pIn) {
     pOut->mat[0] = pIn->mat[0];
     pOut->mat[1] = pIn->mat[1];
     pOut->mat[2] = pIn->mat[2];
@@ -197,7 +197,7 @@ kmMat3* const kmMat3AssignMat4(kmMat3* pOut, const kmMat4* pIn) {
 }
 
 /** Returns true if the 2 matrices are equal (approximately) */
-const int kmMat3AreEqual(const kmMat3* pMat1, const kmMat3* pMat2)
+int kmMat3AreEqual(const kmMat3* pMat1, const kmMat3* pMat2)
 {
 	int i;
 	if (pMat1 == pMat2) {
@@ -215,7 +215,7 @@ const int kmMat3AreEqual(const kmMat3* pMat1, const kmMat3* pMat2)
 }
 
 /* Rotation around the z axis so everything stays planar in XY */
-kmMat3* const kmMat3Rotation(kmMat3* pOut, const kmScalar radians)
+kmMat3* kmMat3Rotation(kmMat3* pOut, const kmScalar radians)
 {
 	/*
          |  cos(A)  -sin(A)   0  |
@@ -239,7 +239,7 @@ kmMat3* const kmMat3Rotation(kmMat3* pOut, const kmScalar radians)
 }
 
 /** Builds a scaling matrix */
-kmMat3* const kmMat3Scaling(kmMat3* pOut, const kmScalar x, const kmScalar y)
+kmMat3* kmMat3Scaling(kmMat3* pOut, const kmScalar x, const kmScalar y)
 {
 //	memset(pOut->mat, 0, sizeof(kmScalar) * 9);
 	kmMat3Identity(pOut);
@@ -249,7 +249,7 @@ kmMat3* const kmMat3Scaling(kmMat3* pOut, const kmScalar x, const kmScalar y)
 	return pOut;
 }
 
-kmMat3* const kmMat3Translation(kmMat3* pOut, const kmScalar x, const kmScalar y)
+kmMat3* kmMat3Translation(kmMat3* pOut, const kmScalar x, const kmScalar y)
 {
 //    memset(pOut->mat, 0, sizeof(kmScalar) * 9);
 	kmMat3Identity(pOut);
@@ -261,7 +261,7 @@ kmMat3* const kmMat3Translation(kmMat3* pOut, const kmScalar x, const kmScalar y
 }
 
 
-kmMat3* const kmMat3RotationQuaternion(kmMat3* pOut, const kmQuaternion* pIn)
+kmMat3* kmMat3RotationQuaternion(kmMat3* pOut, const kmQuaternion* pIn)
 {
     if (!pIn || !pOut) {
 	return NULL;
@@ -285,7 +285,7 @@ kmMat3* const kmMat3RotationQuaternion(kmMat3* pOut, const kmQuaternion* pIn)
     return pOut;
 }
 
-kmMat3* const kmMat3RotationAxisAngle(kmMat3* pOut, const struct kmVec3* axis, kmScalar radians)
+kmMat3* kmMat3RotationAxisAngle(kmMat3* pOut, const struct kmVec3* axis, kmScalar radians)
 {
     kmScalar rcos = cosf(radians);
     kmScalar rsin = sinf(radians);
@@ -305,7 +305,7 @@ kmMat3* const kmMat3RotationAxisAngle(kmMat3* pOut, const struct kmVec3* axis, k
     return pOut;
 }
 
-kmVec3* const kmMat3RotationToAxisAngle(kmVec3* pAxis, kmScalar* radians, const kmMat3* pIn)
+kmVec3* kmMat3RotationToAxisAngle(kmVec3* pAxis, kmScalar* radians, const kmMat3* pIn)
 {
     /*Surely not this easy?*/
     kmQuaternion temp;
@@ -317,7 +317,7 @@ kmVec3* const kmMat3RotationToAxisAngle(kmVec3* pAxis, kmScalar* radians, const 
 /**
  * Builds an X-axis rotation matrix and stores it in pOut, returns pOut
  */
-kmMat3* const kmMat3RotationX(kmMat3* pOut, const kmScalar radians)
+kmMat3* kmMat3RotationX(kmMat3* pOut, const kmScalar radians)
 {
 	/*
 		 |  1  0       0      |
@@ -345,7 +345,7 @@ kmMat3* const kmMat3RotationX(kmMat3* pOut, const kmScalar radians)
  * Builds a rotation matrix using the rotation around the Y-axis
  * The result is stored in pOut, pOut is returned.
  */
-kmMat3* const kmMat3RotationY(kmMat3* pOut, const kmScalar radians)
+kmMat3* kmMat3RotationY(kmMat3* pOut, const kmScalar radians)
 {
 	/*
 	     |  cos(A)  0   sin(A) |
@@ -372,7 +372,7 @@ kmMat3* const kmMat3RotationY(kmMat3* pOut, const kmScalar radians)
  * Builds a rotation matrix around the Z-axis. The resulting
  * matrix is stored in pOut. pOut is returned.
  */
-kmMat3* const kmMat3RotationZ(kmMat3* pOut, const kmScalar radians)
+kmMat3* kmMat3RotationZ(kmMat3* pOut, const kmScalar radians)
 {
 	/*
 	     |  cos(A)  -sin(A)   0  |
@@ -395,7 +395,7 @@ kmMat3* const kmMat3RotationZ(kmMat3* pOut, const kmScalar radians)
 	return pOut;
 }
 
-kmVec3* const kmMat3GetUpVec3(kmVec3* pOut, const kmMat3* pIn) {
+kmVec3* kmMat3GetUpVec3(kmVec3* pOut, const kmMat3* pIn) {
 	pOut->x = pIn->mat[3];
 	pOut->y = pIn->mat[4];
 	pOut->z = pIn->mat[5];
@@ -405,7 +405,7 @@ kmVec3* const kmMat3GetUpVec3(kmVec3* pOut, const kmMat3* pIn) {
 	return pOut;
 }
 
-kmVec3* const kmMat3GetRightVec3(kmVec3* pOut, const kmMat3* pIn) {
+kmVec3* kmMat3GetRightVec3(kmVec3* pOut, const kmMat3* pIn) {
 	pOut->x = pIn->mat[0];
 	pOut->y = pIn->mat[1];
 	pOut->z = pIn->mat[2];
@@ -415,7 +415,7 @@ kmVec3* const kmMat3GetRightVec3(kmVec3* pOut, const kmMat3* pIn) {
 	return pOut;
 }
 
-kmVec3* const kmMat3GetForwardVec3(kmVec3* pOut, const kmMat3* pIn) {
+kmVec3* kmMat3GetForwardVec3(kmVec3* pOut, const kmMat3* pIn) {
 	pOut->x = pIn->mat[6];
 	pOut->y = pIn->mat[7];
 	pOut->z = pIn->mat[8];

--- a/kazmath/mat3.h
+++ b/kazmath/mat3.h
@@ -44,36 +44,36 @@ typedef struct kmMat3{
 extern "C" {
 #endif
 
-kmMat3* const kmMat3Fill(kmMat3* pOut, const kmScalar* pMat);
-kmMat3* const kmMat3Adjugate(kmMat3* pOut, const kmMat3* pIn);
-kmMat3* const kmMat3Identity(kmMat3* pOut);
-kmMat3* const kmMat3Inverse(kmMat3* pOut, const kmMat3* pM);
-const int  kmMat3IsIdentity(const kmMat3* pIn);
-kmMat3* const kmMat3Transpose(kmMat3* pOut, const kmMat3* pIn);
-const kmScalar kmMat3Determinant(const kmMat3* pIn);
-kmMat3* const kmMat3Multiply(kmMat3* pOut, const kmMat3* pM1, const kmMat3* pM2);
-kmMat3* const kmMat3ScalarMultiply(kmMat3* pOut, const kmMat3* pM, const kmScalar pFactor);
+kmMat3* kmMat3Fill(kmMat3* pOut, const kmScalar* pMat);
+kmMat3* kmMat3Adjugate(kmMat3* pOut, const kmMat3* pIn);
+kmMat3* kmMat3Identity(kmMat3* pOut);
+kmMat3* kmMat3Inverse(kmMat3* pOut, const kmMat3* pM);
+int  kmMat3IsIdentity(const kmMat3* pIn);
+kmMat3* kmMat3Transpose(kmMat3* pOut, const kmMat3* pIn);
+kmScalar kmMat3Determinant(const kmMat3* pIn);
+kmMat3* kmMat3Multiply(kmMat3* pOut, const kmMat3* pM1, const kmMat3* pM2);
+kmMat3* kmMat3ScalarMultiply(kmMat3* pOut, const kmMat3* pM, const kmScalar pFactor);
 
-kmMat3* const kmMat3Assign(kmMat3* pOut, const kmMat3* pIn);
-kmMat3* const kmMat3AssignMat4(kmMat3* pOut, const struct kmMat4* pIn);
-const int  kmMat3AreEqual(const kmMat3* pM1, const kmMat3* pM2);
+kmMat3* kmMat3Assign(kmMat3* pOut, const kmMat3* pIn);
+kmMat3* kmMat3AssignMat4(kmMat3* pOut, const struct kmMat4* pIn);
+int  kmMat3AreEqual(const kmMat3* pM1, const kmMat3* pM2);
 
-struct kmVec3* const kmMat3GetUpVec3(struct kmVec3* pOut, const kmMat3* pIn);
-struct kmVec3* const kmMat3GetRightVec3(struct kmVec3* pOut, const kmMat3* pIn);
-struct kmVec3* const kmMat3GetForwardVec3(struct kmVec3* pOut, const kmMat3* pIn);
+struct kmVec3* kmMat3GetUpVec3(struct kmVec3* pOut, const kmMat3* pIn);
+struct kmVec3* kmMat3GetRightVec3(struct kmVec3* pOut, const kmMat3* pIn);
+struct kmVec3* kmMat3GetForwardVec3(struct kmVec3* pOut, const kmMat3* pIn);
 
-kmMat3* const kmMat3RotationX(kmMat3* pOut, const kmScalar radians);
-kmMat3* const kmMat3RotationY(kmMat3* pOut, const kmScalar radians);
-kmMat3* const kmMat3RotationZ(kmMat3* pOut, const kmScalar radians);
+kmMat3* kmMat3RotationX(kmMat3* pOut, const kmScalar radians);
+kmMat3* kmMat3RotationY(kmMat3* pOut, const kmScalar radians);
+kmMat3* kmMat3RotationZ(kmMat3* pOut, const kmScalar radians);
 
-kmMat3* const kmMat3Rotation(kmMat3* pOut, const kmScalar radians);
-kmMat3* const kmMat3Scaling(kmMat3* pOut, const kmScalar x, const kmScalar y);
-kmMat3* const kmMat3Translation(kmMat3* pOut, const kmScalar x, const kmScalar y);
+kmMat3* kmMat3Rotation(kmMat3* pOut, const kmScalar radians);
+kmMat3* kmMat3Scaling(kmMat3* pOut, const kmScalar x, const kmScalar y);
+kmMat3* kmMat3Translation(kmMat3* pOut, const kmScalar x, const kmScalar y);
 
-kmMat3* const kmMat3RotationQuaternion(kmMat3* pOut, const struct kmQuaternion* pIn);
+kmMat3* kmMat3RotationQuaternion(kmMat3* pOut, const struct kmQuaternion* pIn);
 
-kmMat3* const kmMat3RotationAxisAngle(kmMat3* pOut, const struct kmVec3* axis, kmScalar radians);
-struct kmVec3* const kmMat3RotationToAxisAngle(struct kmVec3* pAxis, kmScalar* radians, const kmMat3* pIn);
+kmMat3* kmMat3RotationAxisAngle(kmMat3* pOut, const struct kmVec3* axis, kmScalar radians);
+struct kmVec3* kmMat3RotationToAxisAngle(struct kmVec3* pAxis, kmScalar* radians, const kmMat3* pIn);
 
 #ifdef __cplusplus
 }

--- a/kazmath/mat4.c
+++ b/kazmath/mat4.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * 		   pMat - A 16 element array of kmScalars
  * @Return Returns pOut so that the call can be nested
  */
-kmMat4* const kmMat4Fill(kmMat4* pOut, const kmScalar* pMat)
+kmMat4* kmMat4Fill(kmMat4* pOut, const kmScalar* pMat)
 {
     memcpy(pOut->mat, pMat, sizeof(kmScalar) * 16);
     return pOut;
@@ -55,7 +55,7 @@ kmMat4* const kmMat4Fill(kmMat4* pOut, const kmScalar* pMat)
  * @Params pOut - A pointer to the matrix to set to identity
  * @Return Returns pOut so that the call can be nested
  */
-kmMat4* const kmMat4Identity(kmMat4* pOut)
+kmMat4* kmMat4Identity(kmMat4* pOut)
 {
 	memset(pOut->mat, 0, sizeof(kmScalar) * 16);
 	pOut->mat[0] = pOut->mat[5] = pOut->mat[10] = pOut->mat[15] = 1.0f;
@@ -63,7 +63,7 @@ kmMat4* const kmMat4Identity(kmMat4* pOut)
 }
 
 
-kmScalar get(const kmMat4 * pIn, int row, int col)
+kmScalar get(kmMat4 * pIn, int row, int col)
 {
 	return pIn->mat[row + 4*col];
 }
@@ -162,7 +162,7 @@ int gaussj(kmMat4 *a, kmMat4 *b)
  * pOut.
  * @Return Returns NULL if there is no inverse, else pOut
  */
-kmMat4* const kmMat4Inverse(kmMat4* pOut, const kmMat4* pM)
+kmMat4* kmMat4Inverse(kmMat4* pOut, const kmMat4* pM)
 {
     kmMat4 inv;
     kmMat4Assign(&inv, pM);
@@ -181,9 +181,9 @@ kmMat4* const kmMat4Inverse(kmMat4* pOut, const kmMat4* pM)
  * Returns KM_TRUE if pIn is an identity matrix
  * KM_FALSE otherwise
  */
-const int  kmMat4IsIdentity(const kmMat4* pIn)
+int  kmMat4IsIdentity(const kmMat4* pIn)
 {
-	static const kmScalar identity [] = { 	1.0f, 0.0f, 0.0f, 0.0f,
+	static kmScalar identity [] = { 	1.0f, 0.0f, 0.0f, 0.0f,
 	                                    0.0f, 1.0f, 0.0f, 0.0f,
 	                                    0.0f, 0.0f, 1.0f, 0.0f,
 	                                    0.0f, 0.0f, 0.0f, 1.0f
@@ -195,7 +195,7 @@ const int  kmMat4IsIdentity(const kmMat4* pIn)
 /**
  * Sets pOut to the transpose of pIn, returns pOut
  */
-kmMat4* const kmMat4Transpose(kmMat4* pOut, const kmMat4* pIn)
+kmMat4* kmMat4Transpose(kmMat4* pOut, const kmMat4* pIn)
 {
     int x, z;
 
@@ -211,7 +211,7 @@ kmMat4* const kmMat4Transpose(kmMat4* pOut, const kmMat4* pIn)
 /**
  * Multiplies pM1 with pM2, stores the result in pOut, returns pOut
  */
-kmMat4* const kmMat4Multiply(kmMat4* pOut, const kmMat4* pM1, const kmMat4* pM2)
+kmMat4* kmMat4Multiply(kmMat4* pOut, const kmMat4* pM1, const kmMat4* pM2)
 {
 	kmScalar mat[16];
 
@@ -246,7 +246,7 @@ kmMat4* const kmMat4Multiply(kmMat4* pOut, const kmMat4* pM1, const kmMat4* pM2)
 /**
  * Assigns the value of pIn to pOut
  */
-kmMat4* const kmMat4Assign(kmMat4* pOut, const kmMat4* pIn)
+kmMat4* kmMat4Assign(kmMat4* pOut, const kmMat4* pIn)
 {
 	assert(pOut != pIn && "You have tried to self-assign!!");
 
@@ -255,7 +255,7 @@ kmMat4* const kmMat4Assign(kmMat4* pOut, const kmMat4* pIn)
 	return pOut;
 }
 
-kmMat4* const kmMat4AssignMat3(kmMat4* pOut, const kmMat3* pIn) {
+kmMat4* kmMat4AssignMat3(kmMat4* pOut, const kmMat3* pIn) {
     kmMat4Identity(pOut);
 
     pOut->mat[0] = pIn->mat[0];
@@ -280,7 +280,7 @@ kmMat4* const kmMat4AssignMat3(kmMat4* pOut, const kmMat3* pIn) {
 /**
  * Returns KM_TRUE if the 2 matrices are equal (approximately)
  */
-const int kmMat4AreEqual(const kmMat4* pMat1, const kmMat4* pMat2)
+int kmMat4AreEqual(const kmMat4* pMat1, const kmMat4* pMat2)
 {
     int i = 0;
 
@@ -301,7 +301,7 @@ const int kmMat4AreEqual(const kmMat4* pMat1, const kmMat4* pMat2)
  * Build a rotation matrix from an axis and an angle. Result is stored in pOut.
  * pOut is returned.
  */
-kmMat4* const kmMat4RotationAxisAngle(kmMat4* pOut, const kmVec3* axis, kmScalar radians)
+kmMat4* kmMat4RotationAxisAngle(kmMat4* pOut, const kmVec3* axis, kmScalar radians)
 {
 	kmScalar rcos = cosf(radians);
 	kmScalar rsin = sinf(radians);
@@ -335,7 +335,7 @@ kmMat4* const kmMat4RotationAxisAngle(kmMat4* pOut, const kmVec3* axis, kmScalar
 /**
  * Builds an X-axis rotation matrix and stores it in pOut, returns pOut
  */
-kmMat4* const kmMat4RotationX(kmMat4* pOut, const kmScalar radians)
+kmMat4* kmMat4RotationX(kmMat4* pOut, const kmScalar radians)
 {
 	/*
 		 |  1  0       0       0 |
@@ -372,7 +372,7 @@ kmMat4* const kmMat4RotationX(kmMat4* pOut, const kmScalar radians)
  * Builds a rotation matrix using the rotation around the Y-axis
  * The result is stored in pOut, pOut is returned.
  */
-kmMat4* const kmMat4RotationY(kmMat4* pOut, const kmScalar radians)
+kmMat4* kmMat4RotationY(kmMat4* pOut, const kmScalar radians)
 {
 	/*
 	     |  cos(A)  0   sin(A)  0 |
@@ -408,7 +408,7 @@ kmMat4* const kmMat4RotationY(kmMat4* pOut, const kmScalar radians)
  * Builds a rotation matrix around the Z-axis. The resulting
  * matrix is stored in pOut. pOut is returned.
  */
-kmMat4* const kmMat4RotationZ(kmMat4* pOut, const kmScalar radians)
+kmMat4* kmMat4RotationZ(kmMat4* pOut, const kmScalar radians)
 {
 	/*
 	     |  cos(A)  -sin(A)   0   0 |
@@ -444,7 +444,7 @@ kmMat4* const kmMat4RotationZ(kmMat4* pOut, const kmScalar radians)
  * Builds a rotation matrix from pitch, yaw and roll. The resulting
  * matrix is stored in pOut and pOut is returned
  */
-kmMat4* const kmMat4RotationPitchYawRoll(kmMat4* pOut, const kmScalar pitch, const kmScalar yaw, const kmScalar roll)
+kmMat4* kmMat4RotationPitchYawRoll(kmMat4* pOut, const kmScalar pitch, const kmScalar yaw, const kmScalar roll)
 {
 	double cr = cos(pitch);
 	double sr = sin(pitch);
@@ -476,7 +476,7 @@ kmMat4* const kmMat4RotationPitchYawRoll(kmMat4* pOut, const kmScalar pitch, con
 /** Converts a quaternion to a rotation matrix,
  * the result is stored in pOut, returns pOut
  */
-kmMat4* const kmMat4RotationQuaternion(kmMat4* pOut, const kmQuaternion* pQ)
+kmMat4* kmMat4RotationQuaternion(kmMat4* pOut, const kmQuaternion* pQ)
 {
     kmScalar x2 = pQ->x * pQ->x;
     kmScalar y2 = pQ->y * pQ->y;
@@ -515,8 +515,8 @@ kmMat4* const kmMat4RotationQuaternion(kmMat4* pOut, const kmQuaternion* pQ)
 }
 
 /** Builds a scaling matrix */
-kmMat4* const kmMat4Scaling(kmMat4* pOut, const kmScalar x, const kmScalar y,
-                      const kmScalar z)
+kmMat4* kmMat4Scaling(kmMat4* pOut, const kmScalar x, const kmScalar y,
+                      kmScalar z)
 {
 	memset(pOut->mat, 0, sizeof(kmScalar) * 16);
 	pOut->mat[0] = x;
@@ -531,8 +531,8 @@ kmMat4* const kmMat4Scaling(kmMat4* pOut, const kmScalar x, const kmScalar y,
  * Builds a translation matrix. All other elements in the matrix
  * will be set to zero except for the diagonal which is set to 1.0
  */
-kmMat4* const kmMat4Translation(kmMat4* pOut, const kmScalar x,
-                          const kmScalar y, const kmScalar z)
+kmMat4* kmMat4Translation(kmMat4* pOut, const kmScalar x,
+                          kmScalar y, const kmScalar z)
 {
     //FIXME: Write a test for this
     memset(pOut->mat, 0, sizeof(kmScalar) * 16);
@@ -554,7 +554,7 @@ kmMat4* const kmMat4Translation(kmMat4* pOut, const kmScalar x,
  * wish to extract the vector from. pOut is a pointer to the
  * kmVec3 structure that should hold the resulting vector
  */
-kmVec3* const kmMat4GetUpVec3(kmVec3* pOut, const kmMat4* pIn)
+kmVec3* kmMat4GetUpVec3(kmVec3* pOut, const kmMat4* pIn)
 {
 	pOut->x = pIn->mat[4];
 	pOut->y = pIn->mat[5];
@@ -568,7 +568,7 @@ kmVec3* const kmMat4GetUpVec3(kmVec3* pOut, const kmMat4* pIn)
 /** Extract the right vector from a 4x4 matrix. The result is
  * stored in pOut. Returns pOut.
  */
-kmVec3* const kmMat4GetRightVec3(kmVec3* pOut, const kmMat4* pIn)
+kmVec3* kmMat4GetRightVec3(kmVec3* pOut, const kmMat4* pIn)
 {
 	pOut->x = pIn->mat[0];
 	pOut->y = pIn->mat[1];
@@ -583,7 +583,7 @@ kmVec3* const kmMat4GetRightVec3(kmVec3* pOut, const kmMat4* pIn)
  * Extract the forward vector from a 4x4 matrix. The result is
  * stored in pOut. Returns pOut.
  */
-kmVec3* const kmMat4GetForwardVec3(kmVec3* pOut, const kmMat4* pIn)
+kmVec3* kmMat4GetForwardVec3(kmVec3* pOut, const kmMat4* pIn)
 {
 	pOut->x = pIn->mat[8];
 	pOut->y = pIn->mat[9];
@@ -598,7 +598,7 @@ kmVec3* const kmMat4GetForwardVec3(kmVec3* pOut, const kmMat4* pIn)
  * Creates a perspective projection matrix in the
  * same way as gluPerspective
  */
-kmMat4* const kmMat4PerspectiveProjection(kmMat4* pOut, kmScalar fovY,
+kmMat4* kmMat4PerspectiveProjection(kmMat4* pOut, kmScalar fovY,
                                     kmScalar aspect, kmScalar zNear,
                                     kmScalar zFar)
 {
@@ -626,7 +626,7 @@ kmMat4* const kmMat4PerspectiveProjection(kmMat4* pOut, kmScalar fovY,
 }
 
 /** Creates an orthographic projection matrix like glOrtho */
-kmMat4* const kmMat4OrthographicProjection(kmMat4* pOut, kmScalar left,
+kmMat4* kmMat4OrthographicProjection(kmMat4* pOut, kmScalar left,
                                      kmScalar right, kmScalar bottom,
                                      kmScalar top, kmScalar nearVal,
                                      kmScalar farVal)
@@ -650,7 +650,7 @@ kmMat4* const kmMat4OrthographicProjection(kmMat4* pOut, kmScalar left,
  * Builds a translation matrix in the same way as gluLookAt()
  * the resulting matrix is stored in pOut. pOut is returned.
  */
-kmMat4* const kmMat4LookAt(kmMat4* pOut, const kmVec3* pEye,
+kmMat4* kmMat4LookAt(kmMat4* pOut, const kmVec3* pEye,
                      const kmVec3* pCenter, const kmVec3* pUp)
 {
     kmVec3 f, up, s, u;
@@ -692,7 +692,7 @@ kmMat4* const kmMat4LookAt(kmMat4* pOut, const kmVec3* pEye,
  * Extract a 3x3 rotation matrix from the input 4x4 transformation.
  * Stores the result in pOut, returns pOut
  */
-kmMat3* const kmMat4ExtractRotation(kmMat3* pOut, const kmMat4* pIn)
+kmMat3* kmMat4ExtractRotation(kmMat3* pOut, const kmMat4* pIn)
 {
     pOut->mat[0] = pIn->mat[0];
     pOut->mat[1] = pIn->mat[1];
@@ -713,7 +713,7 @@ kmMat3* const kmMat4ExtractRotation(kmMat3* pOut, const kmMat4* pIn)
  * Take the rotation from a 4x4 transformation matrix, and return it as an axis and an angle (in radians)
  * returns the output axis.
  */
-kmVec3* const kmMat4RotationToAxisAngle(kmVec3* pAxis, kmScalar* radians, const kmMat4* pIn)
+kmVec3* kmMat4RotationToAxisAngle(kmVec3* pAxis, kmScalar* radians, const kmMat4* pIn)
 {
     /*Surely not this easy?*/
     kmQuaternion temp;
@@ -728,7 +728,7 @@ kmVec3* const kmMat4RotationToAxisAngle(kmVec3* pAxis, kmScalar* radians, const 
  * and a 3d vector representing a translation. Assign the result to pOut,
  * pOut is also returned.
  */
-kmMat4* const kmMat4RotationTranslation(kmMat4* pOut, const kmMat3* rotation, const kmVec3* translation)
+kmMat4* kmMat4RotationTranslation(kmMat4* pOut, const kmMat3* rotation, const kmVec3* translation)
 {
     pOut->mat[0] = rotation->mat[0];
     pOut->mat[1] = rotation->mat[1];
@@ -753,7 +753,7 @@ kmMat4* const kmMat4RotationTranslation(kmMat4* pOut, const kmMat3* rotation, co
     return pOut;
 }
 
-kmPlane* const kmMat4ExtractPlane(kmPlane* pOut, const kmMat4* pIn, const kmEnum plane)
+kmPlane* kmMat4ExtractPlane(kmPlane* pOut, const kmMat4* pIn, const kmEnum plane)
 {
     kmScalar t = 1.0f;
 

--- a/kazmath/mat4.h
+++ b/kazmath/mat4.h
@@ -50,45 +50,45 @@ typedef struct kmMat4 {
 	kmScalar mat[16];
 } kmMat4;
 
-kmMat4* const kmMat4Fill(kmMat4* pOut, const kmScalar* pMat);
+kmMat4* kmMat4Fill(kmMat4* pOut, const kmScalar* pMat);
 
 
-kmMat4* const kmMat4Identity(kmMat4* pOut);
+kmMat4* kmMat4Identity(kmMat4* pOut);
 
-kmMat4* const kmMat4Inverse(kmMat4* pOut, const kmMat4* pM);
+kmMat4* kmMat4Inverse(kmMat4* pOut, const kmMat4* pM);
 
 
-const int kmMat4IsIdentity(const kmMat4* pIn);
+int kmMat4IsIdentity(const kmMat4* pIn);
 
-kmMat4* const kmMat4Transpose(kmMat4* pOut, const kmMat4* pIn);
-kmMat4* const kmMat4Multiply(kmMat4* pOut, const kmMat4* pM1, const kmMat4* pM2);
+kmMat4* kmMat4Transpose(kmMat4* pOut, const kmMat4* pIn);
+kmMat4* kmMat4Multiply(kmMat4* pOut, const kmMat4* pM1, const kmMat4* pM2);
 
-kmMat4* const kmMat4Assign(kmMat4* pOut, const kmMat4* pIn);
-kmMat4* const kmMat4AssignMat3(kmMat4* pOut, const struct kmMat3* pIn);
+kmMat4* kmMat4Assign(kmMat4* pOut, const kmMat4* pIn);
+kmMat4* kmMat4AssignMat3(kmMat4* pOut, const struct kmMat3* pIn);
 
-const int kmMat4AreEqual(const kmMat4* pM1, const kmMat4* pM2);
+int kmMat4AreEqual(const kmMat4* pM1, const kmMat4* pM2);
 
-kmMat4* const kmMat4RotationX(kmMat4* pOut, const kmScalar radians);
-kmMat4* const kmMat4RotationY(kmMat4* pOut, const kmScalar radians);
-kmMat4* const kmMat4RotationZ(kmMat4* pOut, const kmScalar radians);
-kmMat4* const kmMat4RotationPitchYawRoll(kmMat4* pOut, const kmScalar pitch, const kmScalar yaw, const kmScalar roll);
-kmMat4* const kmMat4RotationQuaternion(kmMat4* pOut, const struct kmQuaternion* pQ);
-kmMat4* const kmMat4RotationTranslation(kmMat4* pOut, const struct kmMat3* rotation, const struct kmVec3* translation);
-kmMat4* const kmMat4Scaling(kmMat4* pOut, const kmScalar x, const kmScalar y, const kmScalar z);
-kmMat4* const kmMat4Translation(kmMat4* pOut, const kmScalar x, const kmScalar y, const kmScalar z);
+kmMat4* kmMat4RotationX(kmMat4* pOut, const kmScalar radians);
+kmMat4* kmMat4RotationY(kmMat4* pOut, const kmScalar radians);
+kmMat4* kmMat4RotationZ(kmMat4* pOut, const kmScalar radians);
+kmMat4* kmMat4RotationPitchYawRoll(kmMat4* pOut, const kmScalar pitch, const kmScalar yaw, const kmScalar roll);
+kmMat4* kmMat4RotationQuaternion(kmMat4* pOut, const struct kmQuaternion* pQ);
+kmMat4* kmMat4RotationTranslation(kmMat4* pOut, const struct kmMat3* rotation, const struct kmVec3* translation);
+kmMat4* kmMat4Scaling(kmMat4* pOut, const kmScalar x, const kmScalar y, const kmScalar z);
+kmMat4* kmMat4Translation(kmMat4* pOut, const kmScalar x, const kmScalar y, const kmScalar z);
 
-struct kmVec3* const kmMat4GetUpVec3(struct kmVec3* pOut, const kmMat4* pIn);
-struct kmVec3* const kmMat4GetRightVec3(struct kmVec3* pOut, const kmMat4* pIn);
-struct kmVec3* const kmMat4GetForwardVec3(struct kmVec3* pOut, const kmMat4* pIn);
+struct kmVec3* kmMat4GetUpVec3(struct kmVec3* pOut, const kmMat4* pIn);
+struct kmVec3* kmMat4GetRightVec3(struct kmVec3* pOut, const kmMat4* pIn);
+struct kmVec3* kmMat4GetForwardVec3(struct kmVec3* pOut, const kmMat4* pIn);
 
-kmMat4* const kmMat4PerspectiveProjection(kmMat4* pOut, kmScalar fovY, kmScalar aspect, kmScalar zNear, kmScalar zFar);
-kmMat4* const kmMat4OrthographicProjection(kmMat4* pOut, kmScalar left, kmScalar right, kmScalar bottom, kmScalar top, kmScalar nearVal, kmScalar farVal);
-kmMat4* const kmMat4LookAt(kmMat4* pOut, const struct kmVec3* pEye, const struct kmVec3* pCenter, const struct kmVec3* pUp);
+kmMat4* kmMat4PerspectiveProjection(kmMat4* pOut, kmScalar fovY, kmScalar aspect, kmScalar zNear, kmScalar zFar);
+kmMat4* kmMat4OrthographicProjection(kmMat4* pOut, kmScalar left, kmScalar right, kmScalar bottom, kmScalar top, kmScalar nearVal, kmScalar farVal);
+kmMat4* kmMat4LookAt(kmMat4* pOut, const struct kmVec3* pEye, const struct kmVec3* pCenter, const struct kmVec3* pUp);
 
-kmMat4* const kmMat4RotationAxisAngle(kmMat4* pOut, const struct kmVec3* axis, kmScalar radians);
-struct kmMat3* const kmMat4ExtractRotation(struct kmMat3* pOut, const kmMat4* pIn);
-struct kmPlane* const kmMat4ExtractPlane(struct kmPlane* pOut, const kmMat4* pIn, const kmEnum plane);
-struct kmVec3* const kmMat4RotationToAxisAngle(struct kmVec3* pAxis, kmScalar* radians, const kmMat4* pIn);
+kmMat4* kmMat4RotationAxisAngle(kmMat4* pOut, const struct kmVec3* axis, kmScalar radians);
+struct kmMat3* kmMat4ExtractRotation(struct kmMat3* pOut, const kmMat4* pIn);
+struct kmPlane* kmMat4ExtractPlane(struct kmPlane* pOut, const kmMat4* pIn, const kmEnum plane);
+struct kmVec3* kmMat4RotationToAxisAngle(struct kmVec3* pAxis, kmScalar* radians, const kmMat4* pIn);
 #ifdef __cplusplus
 }
 #endif

--- a/kazmath/plane.c
+++ b/kazmath/plane.c
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "plane.h"
 #include "mat4.h"
 
-const kmScalar kmPlaneDot(const kmPlane* pP, const kmVec4* pV)
+kmScalar kmPlaneDot(const kmPlane* pP, const kmVec4* pV)
 {
     //a*x + b*y + c*z + d*w
 
@@ -41,21 +41,21 @@ const kmScalar kmPlaneDot(const kmPlane* pP, const kmVec4* pV)
 	    pP->d * pV->w);
 }
 
-const kmScalar kmPlaneDotCoord(const kmPlane* pP, const kmVec3* pV)
+kmScalar kmPlaneDotCoord(const kmPlane* pP, const kmVec3* pV)
 {
     return (pP->a * pV->x +
 	    pP->b * pV->y +
 	    pP->c * pV->z + pP->d);
 }
 
-const kmScalar kmPlaneDotNormal(const kmPlane* pP, const kmVec3* pV)
+kmScalar kmPlaneDotNormal(const kmPlane* pP, const kmVec3* pV)
 {
     return (pP->a * pV->x +
 	    pP->b * pV->y +
 	    pP->c * pV->z);
 }
 
-kmPlane* const kmPlaneFromPointNormal(kmPlane* pOut, const kmVec3* pPoint, const kmVec3* pNormal)
+kmPlane* kmPlaneFromPointNormal(kmPlane* pOut, const kmVec3* pPoint, const kmVec3* pNormal)
 {
     /*
 	Planea = Nx
@@ -77,7 +77,7 @@ kmPlane* const kmPlaneFromPointNormal(kmPlane* pOut, const kmVec3* pPoint, const
  * Creates a plane from 3 points. The result is stored in pOut.
  * pOut is returned.
  */
-kmPlane* const kmPlaneFromPoints(kmPlane* pOut, const kmVec3* p1, const kmVec3* p2, const kmVec3* p3)
+kmPlane* kmPlaneFromPoints(kmPlane* pOut, const kmVec3* p1, const kmVec3* p2, const kmVec3* p3)
 {
     /*
     v = (B − A) × (C − A)
@@ -104,7 +104,7 @@ kmPlane* const kmPlaneFromPoints(kmPlane* pOut, const kmVec3* p1, const kmVec3* 
 }
 
 // Added by tlensing (http://icedcoffee-framework.org)
-kmVec3* const kmPlaneIntersectLine(kmVec3* pOut, const kmPlane* pP, const kmVec3* pV1, const kmVec3* pV2)
+kmVec3* kmPlaneIntersectLine(kmVec3* pOut, const kmPlane* pP, const kmVec3* pV1, const kmVec3* pV2)
 {
     /*
      n = (Planea, Planeb, Planec)
@@ -136,7 +136,7 @@ kmVec3* const kmPlaneIntersectLine(kmVec3* pOut, const kmPlane* pP, const kmVec3
     return pOut;
 }
 
-kmPlane* const kmPlaneNormalize(kmPlane* pOut, const kmPlane* pP)
+kmPlane* kmPlaneNormalize(kmPlane* pOut, const kmPlane* pP)
 {
 	kmVec3 n;
         kmScalar l = 0;
@@ -165,7 +165,7 @@ kmPlane* const kmPlaneNormalize(kmPlane* pOut, const kmPlane* pP)
 	return pOut;
 }
 
-kmPlane* const kmPlaneScale(kmPlane* pOut, const kmPlane* pP, kmScalar s)
+kmPlane* kmPlaneScale(kmPlane* pOut, const kmPlane* pP, kmScalar s)
 {
 	assert(0 && "Not implemented");
     return NULL;
@@ -175,7 +175,7 @@ kmPlane* const kmPlaneScale(kmPlane* pOut, const kmPlane* pP, kmScalar s)
  * Returns POINT_INFRONT_OF_PLANE if pP is infront of pIn. Returns
  * POINT_BEHIND_PLANE if it is behind. Returns POINT_ON_PLANE otherwise
  */
-const POINT_CLASSIFICATION kmPlaneClassifyPoint(const kmPlane* pIn, const kmVec3* pP)
+POINT_CLASSIFICATION kmPlaneClassifyPoint(const kmPlane* pIn, const kmVec3* pP)
 {
    // This function will determine if a point is on, in front of, or behind
    // the plane.  First we store the dot product of the plane and the point.

--- a/kazmath/plane.h
+++ b/kazmath/plane.h
@@ -53,18 +53,18 @@ typedef enum POINT_CLASSIFICATION {
 	POINT_ON_PLANE,
 } POINT_CLASSIFICATION;
 
-const kmScalar kmPlaneDot(const kmPlane* pP, const struct kmVec4* pV);
-const kmScalar kmPlaneDotCoord(const kmPlane* pP, const struct kmVec3* pV);
-const kmScalar kmPlaneDotNormal(const kmPlane* pP, const struct kmVec3* pV);
-kmPlane* const kmPlaneFromPointNormal(kmPlane* pOut, const struct kmVec3* pPoint, const struct kmVec3* pNormal);
-kmPlane* const kmPlaneFromPoints(kmPlane* pOut, const struct kmVec3* p1, const struct kmVec3* p2, const struct kmVec3* p3);
-kmVec3*  const kmPlaneIntersectLine(struct kmVec3* pOut, const kmPlane* pP, const struct kmVec3* pV1, const struct kmVec3* pV2);
-kmPlane* const kmPlaneNormalize(kmPlane* pOut, const kmPlane* pP);
-kmPlane* const kmPlaneScale(kmPlane* pOut, const kmPlane* pP, kmScalar s);
-const POINT_CLASSIFICATION kmPlaneClassifyPoint(const kmPlane* pIn, const kmVec3* pP); /** Classifys a point against a plane */
+kmScalar kmPlaneDot(const kmPlane* pP, const struct kmVec4* pV);
+kmScalar kmPlaneDotCoord(const kmPlane* pP, const struct kmVec3* pV);
+kmScalar kmPlaneDotNormal(const kmPlane* pP, const struct kmVec3* pV);
+kmPlane* kmPlaneFromPointNormal(kmPlane* pOut, const struct kmVec3* pPoint, const struct kmVec3* pNormal);
+kmPlane* kmPlaneFromPoints(kmPlane* pOut, const struct kmVec3* p1, const struct kmVec3* p2, const struct kmVec3* p3);
+struct kmVec3* kmPlaneIntersectLine(struct kmVec3* pOut, const kmPlane* pP, const struct kmVec3* pV1, const struct kmVec3* pV2);
+kmPlane* kmPlaneNormalize(kmPlane* pOut, const kmPlane* pP);
+kmPlane* kmPlaneScale(kmPlane* pOut, const kmPlane* pP, kmScalar s);
+POINT_CLASSIFICATION kmPlaneClassifyPoint(const kmPlane* pIn, const struct kmVec3* pP); /** Classifys a point against a plane */
 
 kmPlane* kmPlaneExtractFromMat4(kmPlane* pOut, const struct kmMat4* pIn, kmInt row);
-kmVec3* kmPlaneGetIntersection(kmVec3* pOut, const kmPlane* p1, const kmPlane* p2, const kmPlane* p3);
+struct kmVec3* kmPlaneGetIntersection(struct kmVec3* pOut, const kmPlane* p1, const kmPlane* p2, const kmPlane* p3);
 
 #ifdef __cplusplus
 }

--- a/kazmath/quaternion.c
+++ b/kazmath/quaternion.c
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "quaternion.h"
 
 ///< Returns pOut, sets pOut to the conjugate of pIn
-kmQuaternion* const kmQuaternionConjugate(kmQuaternion* pOut, const kmQuaternion* pIn)
+kmQuaternion* kmQuaternionConjugate(kmQuaternion* pOut, const kmQuaternion* pIn)
 {
 	pOut->x = -pIn->x;
 	pOut->y = -pIn->y;
@@ -44,7 +44,7 @@ kmQuaternion* const kmQuaternionConjugate(kmQuaternion* pOut, const kmQuaternion
 }
 
 ///< Returns the dot product of the 2 quaternions
-const kmScalar kmQuaternionDot(const kmQuaternion* q1, const kmQuaternion* q2)
+kmScalar kmQuaternionDot(const kmQuaternion* q1, const kmQuaternion* q2)
 {
 	/* A dot B = B dot A = AtBt + AxBx + AyBy + AzBz */
 

--- a/kazmath/quaternion.h
+++ b/kazmath/quaternion.h
@@ -43,9 +43,9 @@ typedef struct kmQuaternion {
 	kmScalar w;
 } kmQuaternion;
 
-kmQuaternion* const kmQuaternionConjugate(kmQuaternion* pOut, const kmQuaternion* pIn); ///< Returns pOut, sets pOut to the conjugate of pIn
+kmQuaternion* kmQuaternionConjugate(kmQuaternion* pOut, const kmQuaternion* pIn); ///< Returns pOut, sets pOut to the conjugate of pIn
 
-const kmScalar 	kmQuaternionDot(const kmQuaternion* q1, const kmQuaternion* q2); ///< Returns the dot product of the 2 quaternions
+kmScalar kmQuaternionDot(const kmQuaternion* q1, const kmQuaternion* q2); ///< Returns the dot product of the 2 quaternions
 
 kmQuaternion* kmQuaternionExp(kmQuaternion* pOut, const kmQuaternion* pIn); ///< Returns the exponential of the quaternion
 
@@ -55,8 +55,7 @@ kmQuaternion* kmQuaternionIdentity(kmQuaternion* pOut);
 
 ///< Returns the inverse of the passed Quaternion
 
-kmQuaternion* kmQuaternionInverse(kmQuaternion* pOut,
-											const kmQuaternion* pIn);
+kmQuaternion* kmQuaternionInverse(kmQuaternion* pOut, const kmQuaternion* pIn);
 
 ///< Returns true if the quaternion is an identity quaternion
 


### PR DESCRIPTION
Makes the GCC's -Wextra output silent hopefully.
There might be more warnings when compiling with clang.
