### PR TITLE
Lerp for vectors

### DIFF
--- a/kazmath/aabb.c
+++ b/kazmath/aabb.c
@@ -79,6 +79,7 @@ kmAABB* kmAABBAssign(kmAABB* pOut, const kmAABB* pIn)
 kmAABB* kmAABBScale(kmAABB* pOut, const kmAABB* pIn, kmScalar s)
 {
 	assert(0 && "Not implemented");
+    return pOut;
 }
 
 kmBool kmAABBIntersectsTriangle(kmAABB* box, const kmVec3* p1, const kmVec3* p2, const kmVec3* p3) {

--- a/kazmath/ray2.c
+++ b/kazmath/ray2.c
@@ -196,4 +196,5 @@ kmVec2* intersection, kmVec2* normal_out) {
 
 kmBool kmRay2IntersectCircle(const kmRay2* ray, const kmVec2 centre, const kmScalar radius, kmVec2* intersection) {
     assert(0 && "Not implemented");
+    return KM_TRUE;
 }

--- a/kazmath/utility.c
+++ b/kazmath/utility.c
@@ -62,3 +62,8 @@ kmScalar kmClamp(kmScalar x, kmScalar min, kmScalar max)
 {
     return x < min ? min : (x > max ? max : x);
 }
+
+kmScalar kmLerp(kmScalar x, kmScalar y, kmScalar t )
+{
+    return x + t * ( y - x );
+}

--- a/kazmath/utility.h
+++ b/kazmath/utility.h
@@ -87,6 +87,7 @@ extern kmScalar max(kmScalar lhs, kmScalar rhs);
 extern kmBool kmAlmostEqual(kmScalar lhs, kmScalar rhs);
 
 extern kmScalar kmClamp(kmScalar x, kmScalar min, kmScalar max);
+extern kmScalar kmLerp(kmScalar x, kmScalar y, kmScalar factor);
 
 #ifdef __cplusplus
 }

--- a/kazmath/vec2.c
+++ b/kazmath/vec2.c
@@ -47,6 +47,12 @@ kmScalar kmVec2LengthSq(const kmVec2* pIn)
     return kmSQR(pIn->x) + kmSQR(pIn->y);
 }
 
+kmVec2* kmVec3Lerp(kmVec2* pOut, const kmVec2* pV1, const kmVec2* pV2, kmScalar t) {
+    pOut->x = pV1->x + t * ( pV2->x - pV1->x ); 
+    pOut->y = pV1->y + t * ( pV2->y - pV1->y ); 
+    return pOut;
+}
+
 kmVec2* kmVec2Normalize(kmVec2* pOut, const kmVec2* pIn)
 {
         if (!pIn->x && !pIn->y)

--- a/kazmath/vec2.h
+++ b/kazmath/vec2.h
@@ -47,6 +47,7 @@ kmVec2* kmVec2Fill(kmVec2* pOut, kmScalar x, kmScalar y);
 kmScalar kmVec2Length(const kmVec2* pIn); ///< Returns the length of the vector
 kmScalar kmVec2LengthSq(const kmVec2* pIn); ///< Returns the square of the length of the vector
 kmVec2* kmVec2Normalize(kmVec2* pOut, const kmVec2* pIn); ///< Returns the vector passed in set to unit length
+kmVec2* kmVec2Lerp(kmVec2* pOut, const kmVec2* pV1, const kmVec2* pV2, kmScalar t);
 kmVec2* kmVec2Add(kmVec2* pOut, const kmVec2* pV1, const kmVec2* pV2); ///< Adds 2 vectors and returns the result
 kmScalar kmVec2Dot(const kmVec2* pV1, const kmVec2* pV2); /** Returns the Dot product which is the cosine of the angle between the two vectors multiplied by their lengths */
 kmScalar kmVec2Cross(const kmVec2* pV1, const kmVec2* pV2);

--- a/kazmath/vec3.c
+++ b/kazmath/vec3.c
@@ -74,6 +74,14 @@ kmScalar kmVec3LengthSq(const kmVec3* pIn)
 	return kmSQR(pIn->x) + kmSQR(pIn->y) + kmSQR(pIn->z);
 }
 
+/// Returns the interpolation of 2 4D vectors based on t.
+kmVec3* kmVec3Lerp(kmVec3* pOut, const kmVec3* pV1, const kmVec3* pV2, kmScalar t) {
+    pOut->x = pV1->x + t * ( pV2->x - pV1->x ); 
+    pOut->y = pV1->y + t * ( pV2->y - pV1->y ); 
+    pOut->z = pV1->z + t * ( pV2->z - pV1->z ); 
+    return pOut;
+}
+
  /**
   * Returns the vector passed in set to unit length
   * the result is stored in pOut.

--- a/kazmath/vec3.h
+++ b/kazmath/vec3.h
@@ -46,6 +46,7 @@ extern "C" {
 kmVec3* kmVec3Fill(kmVec3* pOut, kmScalar x, kmScalar y, kmScalar z);
 kmScalar kmVec3Length(const kmVec3* pIn); /** Returns the length of the vector */
 kmScalar kmVec3LengthSq(const kmVec3* pIn); /** Returns the square of the length of the vector */
+kmVec3* kmVec3Lerp(kmVec3* pOut, const kmVec3* pV1, const kmVec3* pV2, kmScalar t);
 kmVec3* kmVec3Normalize(kmVec3* pOut, const kmVec3* pIn); /** Returns the vector passed in set to unit length */
 kmVec3* kmVec3Cross(kmVec3* pOut, const kmVec3* pV1, const kmVec3* pV2); /** Returns a vector perpendicular to 2 other vectors */
 kmScalar kmVec3Dot(const kmVec3* pV1, const kmVec3* pV2); /** Returns the cosine of the angle between 2 vectors */

--- a/kazmath/vec4.c
+++ b/kazmath/vec4.c
@@ -72,29 +72,26 @@ kmScalar kmVec4LengthSq(const kmVec4* pIn) {
 	return kmSQR(pIn->x) + kmSQR(pIn->y) + kmSQR(pIn->z) + kmSQR(pIn->w);
 }
 
-/// Returns the interpolation of 2 4D vectors based on t. Currently not implemented!
+/// Returns the interpolation of 2 4D vectors based on t.
 kmVec4* kmVec4Lerp(kmVec4* pOut, const kmVec4* pV1, const kmVec4* pV2, kmScalar t) {
-    assert(0);
+    pOut->x = pV1->x + t * ( pV2->x - pV1->x ); 
+    pOut->y = pV1->y + t * ( pV2->y - pV1->y ); 
+    pOut->z = pV1->z + t * ( pV2->z - pV1->z ); 
+    pOut->w = pV1->w + t * ( pV2->w - pV1->w ); 
     return pOut;
 }
 
 /// Normalizes a 4D vector. The result is stored in pOut. pOut is returned
 kmVec4* kmVec4Normalize(kmVec4* pOut, const kmVec4* pIn) {
-    if (!pIn->x && !pIn->y && !pIn->z && !pIn->w)
+    if (!pIn->x && !pIn->y && !pIn->z && !pIn->w){
         return kmVec4Assign(pOut, pIn);
+    }
 
 	kmScalar l = 1.0f / kmVec4Length(pIn);
-
-	kmVec4 v;
-	v.x = pIn->x * l;
-	v.y = pIn->y * l;
-	v.z = pIn->z * l;
-	v.w = pIn->w * l;
-
-	pOut->x = v.x;
-	pOut->y = v.y;
-	pOut->z = v.z;
-	pOut->w = v.w;
+    pOut->x = pIn->x * l;
+	pOut->y = pIn->y * l;
+	pOut->z = pIn->z * l;
+	pOut->w = pIn->w * l;
 
 	return pOut;
 }

--- a/kazmath/vec4.h
+++ b/kazmath/vec4.h
@@ -33,7 +33,8 @@ struct kmMat4;
 #pragma pack(push)  /* push current alignment to stack */
 #pragma pack(1)     /* set alignment to 1 byte boundary */
 
-typedef struct kmVec4 {
+typedef struct kmVec4
+{
 	kmScalar x;
 	kmScalar y;
 	kmScalar z;


### PR DESCRIPTION
Added linear interpolation for vectors and also for scalars. 
Also fixed a couple of return values that were giving errors in VS2010.
Removed unnnecessary temp variable in kmVec4Normalize. 
