### PR TITLE
Fix name for definition of vec2lerp

### DIFF
--- a/kazmath/vec2.c
+++ b/kazmath/vec2.c
@@ -47,7 +47,7 @@ kmScalar kmVec2LengthSq(const kmVec2* pIn)
     return kmSQR(pIn->x) + kmSQR(pIn->y);
 }
 
-kmVec2* kmVec3Lerp(kmVec2* pOut, const kmVec2* pV1, const kmVec2* pV2, kmScalar t) {
+kmVec2* kmVec2Lerp(kmVec2* pOut, const kmVec2* pV1, const kmVec2* pV2, kmScalar t) {
     pOut->x = pV1->x + t * ( pV2->x - pV1->x ); 
     pOut->y = pV1->y + t * ( pV2->y - pV1->y ); 
     return pOut;


### PR DESCRIPTION
Sorry for the typo. It didn't give me any error, so I didn't see it. 
