### PR TITLE
Added intersection success return value to kmRay3IntersectPlane

### DIFF
--- a/kazmath/ray3.c
+++ b/kazmath/ray3.c
@@ -19,7 +19,7 @@ kmRay3* kmRay3FromPointAndDirection(kmRay3* ray, const kmVec3* point, const kmVe
     return ray;
 }
 
-kmVec3* kmRay3IntersectPlane(kmVec3* pOut, const kmRay3* ray, const kmPlane* plane) {
+kmBool kmRay3IntersectPlane(kmVec3* pOut, const kmRay3* ray, const kmPlane* plane) {
     //t = - (A*org.x + B*org.y + C*org.z + D) / (A*dir.x + B*dir.y + C*dir.z )
     double t = -(plane->a * ray->start.x +
                  plane->b * ray->start.y +
@@ -28,9 +28,13 @@ kmVec3* kmRay3IntersectPlane(kmVec3* pOut, const kmRay3* ray, const kmPlane* pla
                  plane->b * ray->dir.y +
                  plane->c * ray->dir.z);
 
+    if(t < 0)
+    {
+      return KM_FALSE;
+    }
 
     kmVec3 scaled_dir;
     kmVec3Scale(&scaled_dir, &ray->dir, t);
     kmVec3Add(pOut, &ray->start, &scaled_dir);
-    return pOut;
+    return KM_TRUE;
 }

--- a/kazmath/ray3.h
+++ b/kazmath/ray3.h
@@ -17,7 +17,7 @@ struct kmPlane;
 
 kmRay3* kmRay3Fill(kmRay3* ray, kmScalar px, kmScalar py, kmScalar pz, kmScalar vx, kmScalar vy, kmScalar vz);
 kmRay3* kmRay3FromPointAndDirection(kmRay3* ray, const kmVec3* point, const kmVec3* direction);
-kmVec3* kmRay3IntersectPlane(kmVec3* pOut, const kmRay3* ray, const struct kmPlane* plane);
+kmBool kmRay3IntersectPlane(kmVec3* pOut, const kmRay3* ray, const struct kmPlane* plane);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Currently kmRay3IntersectPlane differs from all other intersection test functions by not having a success return value. The function also produces erronous values when the ray and plane do not intersect. 

This commit makes the function correctly return false when the scalar t is negative (collision point behind the ray or ray and plane are parallel).
