### PR TITLE
Added vector reflect functions

### DIFF
--- a/kazmath/vec2.c
+++ b/kazmath/vec2.c
@@ -237,3 +237,15 @@ kmVec2* kmVec2MidPointBetween(kmVec2* pOut, const kmVec2* v1, const kmVec2* v2) 
 
 	return pOut;
 }
+
+/**
+ * Reflects a vector about a given surface normal. The surface normal is
+ * assumed to be of unit length.
+ */
+kmVec2* kmVec2Reflect(kmVec2* pOut, const kmVec2* pIn, const kmVec2* normal) {
+	kmVec2 tmp;
+	kmVec2Scale(&tmp, normal, 2.0f * kmVec2Dot(pIn, normal));
+	kmVec2Subtract(pOut, pIn, &tmp);
+
+	return pOut;
+}

--- a/kazmath/vec2.h
+++ b/kazmath/vec2.h
@@ -63,6 +63,7 @@ kmVec2* kmVec2RotateBy(kmVec2* pOut, const kmVec2* pIn, const kmScalar degrees, 
 kmScalar kmVec2DegreesBetween(const kmVec2* v1, const kmVec2* v2);
 kmScalar kmVec2DistanceBetween(const kmVec2* v1, const kmVec2* v2);
 kmVec2* kmVec2MidPointBetween(kmVec2* pOut, const kmVec2* v1, const kmVec2* v2);
+kmVec2* kmVec2Reflect(kmVec2* pOut, const kmVec2* pIn, const kmVec2* normal); /**< Reflects a vector about a given surface normal. The surface normal is assumed to be of unit length. */
 
 extern const kmVec2 KM_VEC2_POS_Y;
 extern const kmVec2 KM_VEC2_NEG_Y;

--- a/kazmath/vec3.c
+++ b/kazmath/vec3.c
@@ -442,3 +442,15 @@ kmVec3* kmVec3ProjectOnToPlane(kmVec3* pOut, const kmVec3* point, const struct k
     kmRay3IntersectPlane(pOut, &ray, plane);
     return pOut;
 }
+
+/**
+ * Reflects a vector about a given surface normal. The surface normal is
+ * assumed to be of unit length.
+ */
+kmVec3* kmVec3Reflect(kmVec3* pOut, const kmVec3* pIn, const kmVec3* normal) {
+  kmVec3 tmp;
+  kmVec3Scale(&tmp, normal, 2.0f * kmVec3Dot(pIn, normal));
+  kmVec3Subtract(pOut, pIn, &tmp);
+
+  return pOut;
+}

--- a/kazmath/vec3.h
+++ b/kazmath/vec3.h
@@ -73,6 +73,8 @@ kmVec3* kmVec3RotationToDirection(kmVec3* pOut, const kmVec3* pIn, const kmVec3*
 
 kmVec3* kmVec3ProjectOnToPlane(kmVec3* pOut, const kmVec3* point, const struct kmPlane* plane);
 
+kmVec3* kmVec3Reflect(kmVec3* pOut, const kmVec3* pIn, const kmVec3* normal); /**< Reflects a vector about a given surface normal. The surface normal is assumed to be of unit length. */
+
 extern const kmVec3 KM_VEC3_NEG_Z;
 extern const kmVec3 KM_VEC3_POS_Z;
 extern const kmVec3 KM_VEC3_POS_Y;

--- a/tests/test_vec2.cpp
+++ b/tests/test_vec2.cpp
@@ -18,6 +18,17 @@ TEST(test_transform) {
     CHECK_CLOSE(0.0f, rotated.y, 0.001f);
 }
 
+TEST(test_vec2_reflect) {
+    kmVec2 incident;
+    kmVec2Fill(&incident, 1.0f, -1.0f);
+
+    kmVec2 reflected;
+    kmVec2Reflect(&reflected, &incident, &KM_VEC2_POS_Y);
+
+    CHECK_CLOSE(1.0f, reflected.x, 0.001f);
+    CHECK_CLOSE(1.0f, reflected.y, 0.001f);
+}
+
 TEST(test_degrees_between) {
     kmVec2 v1;
     kmVec2 v2;

--- a/tests/test_vec3.cpp
+++ b/tests/test_vec3.cpp
@@ -18,3 +18,15 @@ TEST(test_project_onto_plane) {
     CHECK_CLOSE(10.0, result.y, 0.0001);
     CHECK_CLOSE(0.0, result.z, 0.0001);
 }
+
+TEST(test_vec3_reflect) {
+    kmVec3 incident;
+    kmVec3Fill(&incident, 7.0f, -5.0f, 3.0f);
+
+    kmVec3 reflected;
+    kmVec3Reflect(&reflected, &incident, &KM_VEC3_POS_Y);
+
+    CHECK_CLOSE(7.0f, reflected.x, 0.001f);
+    CHECK_CLOSE(5.0f, reflected.y, 0.001f);
+    CHECK_CLOSE(3.0f, reflected.z, 0.001f);
+}


### PR DESCRIPTION
This PR adds "reflect" functions for 2D and 3D vectors, which reflect an incident vector about a surface normal. The behaviour of these functions is identical to that provided in GLSL (https://www.opengl.org/sdk/docs/man4/html/reflect.xhtml) and GLM (https://github.com/g-truc/glm/blob/2ddfbd23c622969df79476f64e686779bf8c9163/glm/detail/func_geometric.inl#L174). I found that I needed this functionality when adding planar reflections to a 3D scene.

Note: test_ray_plane_intersection was failing on my machine before I made any changes.