### PR TITLE
Update the kmPlaneFill function prototype to match its definition.

### DIFF
--- a/kazmath/plane.h
+++ b/kazmath/plane.h
@@ -53,7 +53,7 @@ typedef enum KM_POINT_CLASSIFICATION {
     POINT_INFRONT_OF_PLANE = 1
 } KM_POINT_CLASSIFICATION;
 
-kmPlane* kmPlaneFill(kmPlane* plane, float a, float b, float c, float d);
+kmPlane* kmPlaneFill(kmPlane* plane, kmScalar a, kmScalar b, kmScalar c, kmScalar d);
 kmScalar kmPlaneDot(const kmPlane* pP, const struct kmVec4* pV);
 kmScalar kmPlaneDotCoord(const kmPlane* pP, const struct kmVec3* pV);
 kmScalar kmPlaneDotNormal(const kmPlane* pP, const struct kmVec3* pV);


### PR DESCRIPTION
This fixes a warning when `USE_DOUBLE_PRECISION` is defined.