### PR TITLE
docs: fix simple typo, exmaple -> example

### DIFF
--- a/lua/README.md
+++ b/lua/README.md
@@ -22,7 +22,7 @@ assert(tbl.z == 3)
 
 Implemented for kmVec*, kmRay*, kmPlane, kmQuaternion
 
-for exmaple
+for example
 ```
 local vec2 = lkazmath.kmVec2New()
 vec2.x = 5


### PR DESCRIPTION
There is a small typo in lua/README.md.

Should read `example` rather than `exmaple`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md